### PR TITLE
Fixed header not resizing properly at breakpoints

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,7 +23,6 @@ html {
       font-size: 75%; } }
 
 .container {
-  width: 112rem;
   margin: 0 auto; }
 
 .mt-large {
@@ -136,7 +135,8 @@ html {
     align-items: center;
     justify-content: space-between;
     height: 10rem;
-    font-size: 1.5rem; }
+    font-size: 1.5rem;
+    padding: 0 2rem; }
 
 .main-section {
   width: 97%;

--- a/sass/base/_base.scss
+++ b/sass/base/_base.scss
@@ -30,6 +30,6 @@ html {
 }
 
 .container {
-  width: 112rem;
+  // width: 112rem;
   margin: 0 auto;
 }

--- a/sass/layout/_header.scss
+++ b/sass/layout/_header.scss
@@ -1,18 +1,17 @@
 .header {
-    background-color: $color-navy;
+  background-color: $color-navy;
+  height: 10rem;
+  color: $color-white;
+
+  width: 100%;
+  z-index: 120;
+
+  &__section {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     height: 10rem;
-    color: $color-white;
-
-    width: 100%;
-    z-index: 120;
-
-    &__section {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        height: 10rem;
-        font-size: 1.5rem;
-    }
-    
-
+    font-size: 1.5rem;
+    padding: 0 2rem;
+  }
 }


### PR DESCRIPTION
- .container had a fixed width, removed it
- added padding to the header__section to give the header__logo and header__contact some clearance on the left and right sides